### PR TITLE
check existence before trying to remove the previous file

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -54,7 +54,7 @@ import <- function(
 {
   imports <- find_staticimports(dir)
 
-  if (is.character(outfile)) {
+  if (is.character(outfile) && file.exists(outfile)) {
     file.remove(outfile)
   }
   for (import in imports) {


### PR DESCRIPTION
Otherwise we get something like this 
````r
> staticimports::import()
Writing to C:/Users/chris/Documents/DEV_R/pandoc/R/staticimports.R
Warning message:
In file.remove(outfile) :
  cannot remove file 'C:/Users/chris/Documents/DEV_R/pandoc/R/staticimports.R', reason 'No such file or directory'
````

