### PR TITLE
Add is_rcmd_check() helper

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -1,0 +1,3 @@
+is_rcmd_check <- function() {
+  Sys.getenv("_R_CHECK_PACKAGE_NAME_", "") != ""
+}


### PR DESCRIPTION
This helper is useful as soon as a special handling is needed for R CMD check. 

Hope you don't mind the PR. 😅 
As I was working on new package, I took the opportunity to add what I was retrieving elsewhere. Probably last one I can think of that would benefit being in there. I thought it would be clever to add here that adding in another place. But I may be wrong. 

Feel free to ignore.
