### PR TITLE
Use parse data to extract staticexports from source text

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Imports:
-    here
+    here,
+    utils
 Suggests:
     rmarkdown,
     knitr,

--- a/R/import.R
+++ b/R/import.R
@@ -100,10 +100,8 @@ import_objs <- function(
   } else {
     env <- new.env()
     files <- dir(source, pattern = "\\.[r|R]$", full.names = TRUE)
-    source_text <- list() # The contents of each file
     for (file in files) {
       source(file, local = env, keep.source = TRUE)
-      source_text[[file]] <- readLines(file)
     }
   }
 
@@ -122,7 +120,7 @@ import_objs <- function(
 
   all_dep_objs <- mget(all_dep_names, env)
 
-  all_source_text <- process_source_texts(source_text)
+  all_source_text <- process_source_files(files)
 
   # Given a list of functions (with source refs), write the source to a file.
   write_deps <- function(fns, outfile) {

--- a/R/import.R
+++ b/R/import.R
@@ -100,8 +100,10 @@ import_objs <- function(
   } else {
     env <- new.env()
     files <- dir(source, pattern = "\\.[r|R]$", full.names = TRUE)
+    source_text <- list() # The contents of each file
     for (file in files) {
       source(file, local = env, keep.source = TRUE)
+      source_text[[file]] <- readLines(file)
     }
   }
 
@@ -120,7 +122,7 @@ import_objs <- function(
 
   all_dep_objs <- mget(all_dep_names, env)
 
-  all_source_text <- process_source_files(files)
+  all_source_text <- process_source_texts(source_text)
 
   # Given a list of functions (with source refs), write the source to a file.
   write_deps <- function(fns, outfile) {

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -20,12 +20,12 @@ process_source_text_one <- function(text) {
   # Top-level expressions have a parent attribute of 0
   object_definitions <- assignments[assignments$parent == 0, ]
 
-  staticexports <- vector("list", nrow(object_definitions))
+  result <- vector("list", nrow(object_definitions))
 
   for (i in seq_len(nrow(object_definitions))) {
     object_definition <- object_definitions[i, ]
 
-    names(staticexports)[i] <- extract_object_name(
+    names(result)[i] <- extract_object_name(
       parse_data, object_definition, assignment_ops
     )
 
@@ -39,15 +39,14 @@ process_source_text_one <- function(text) {
         rev(seq_len(nrow(leading_comments))),
     ]
 
-    staticexport_lines <- seq(
+    staticexport_lines_idx <- seq(
       min(leading_comments$line1, object_definition$line1),
       max(leading_comments$line2, object_definition$line2)
     )
-    staticexport_text <- text[staticexport_lines]
-    staticexports[[i]] <- staticexport_text
+    result[[i]] <- text[staticexport_lines_idx]
   }
 
-  staticexports
+  result
 }
 
 extract_object_name <- function(parse_data, object_definition, assignment_ops) {

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -57,7 +57,7 @@ extract_object_name <- function(parse_data, object_definition, assignment_ops) {
 
   object_name_expr <- parse_data[
     parse_data$parent == object_definition$id &
-      if (assignment$token %in% c("LEFT_ASSIGN", "RIGHT_ASSIGN")) {
+      if (assignment$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN")) {
         parse_data$line2 <= assignment$line1 & parse_data$col2 < assignment$col1
       } else {
         parse_data$line1 >= assignment$line2 & parse_data$col1 > assignment$col2

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -13,7 +13,7 @@ process_source_text_one <- function(text) {
   )
 
   assignment_ops <- parse_data[
-    parse_data$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN", "RIGHT_ASSIGN"),
+    parse_data$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN"),
   ]
   # Assignments are the parent expressions of assignment operators
   assignments <- parse_data[parse_data$id %in% assignment_ops$parent, ]
@@ -55,11 +55,8 @@ extract_object_name <- function(parse_data, object_definition, assignment_ops) {
 
   object_name_expr <- parse_data[
     parse_data$parent == object_definition$id &
-      if (assignment$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN")) {
-        parse_data$line2 <= assignment$line1 & parse_data$col2 < assignment$col1
-      } else {
-        parse_data$line1 >= assignment$line2 & parse_data$col1 > assignment$col2
-      },
+      parse_data$line2 <= assignment$line1 &
+      parse_data$col2 < assignment$col1,
   ]
 
   result <- utils::getParseText(parse_data, object_name_expr$id)

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -1,16 +1,13 @@
-# Given a list of char vectors (each should be the output of `readLines()`),
-# process the text and return a named list of objects.
-process_source_texts <- function(source_texts) {
-  results <- lapply(source_texts, process_source_text_one)
+# Given a list of files, process the text and return a named list of objects.
+process_source_files <- function(files) {
+  results <- lapply(files, process_source_file_one)
   unlist(unname(results), recursive = FALSE)
 }
 
-# Given a char vector of lines (from readLines()), process the text and return a
-# named list of objects.
-process_source_text_one <- function(text) {
-  parse_data <- utils::getParseData(
-    parse(text = paste(text, collapse = "\n"), keep.source = TRUE)
-  )
+# Given a file, process the text and return a named list of objects.
+process_source_file_one <- function(file) {
+  parse_data <- utils::getParseData(parse(file = file, keep.source = TRUE))
+  text <- readLines(file)
 
   assignment_ops <- parse_data[
     parse_data$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN", "RIGHT_ASSIGN"),

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -2,7 +2,7 @@
 # process the text and return a named list of objects.
 process_source_texts <- function(source_texts) {
   results <- lapply(source_texts, process_source_text_one)
-  unlist(results, recursive = FALSE)
+  unlist(unname(results), recursive = FALSE)
 }
 
 # Given a char vector of lines (from readLines()), process the text and return a

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -33,14 +33,7 @@ process_source_text_one <- function(text) {
     start_line <- parse_data[parse_data$id == id, "line1"]
     end_line <- parse_data[parse_data$id == id, "line2"]
 
-    # A comment's parent attribute is 0 - the next expression's id
-    comments <- parse_data[parse_data$parent == -id, ]
-    # Include comments if there are no empty lines between the comment
-    # and the object definition
-    leading_comments_idx <- which(
-      start_line - comments$line1 <= rev(seq_len(nrow(comments)))
-    )
-    comment_lines <- comments[leading_comments_idx, "line1"]
+    comment_lines <- find_leading_comment_lines(parse_data, id, start_line)
 
     staticexport_lines_idx <- seq(min(comment_lines, start_line), end_line)
     result[[i]] <- text[staticexport_lines_idx]
@@ -49,6 +42,21 @@ process_source_text_one <- function(text) {
   }
 
   result
+}
+
+find_leading_comment_lines <- function(
+  parse_data, definition_id, definition_start_line
+) {
+  # A comment's parent attribute is 0 - the next expression's id
+  comment_lines <- parse_data[parse_data$parent == -definition_id, "line1"]
+
+  # Include comments if there are no empty lines between the comment
+  # and the object definition
+  leading_comments_idx <- which(
+    definition_start_line - comment_lines <= rev(seq_along(comment_lines))
+  )
+
+  comment_lines[leading_comments_idx]
 }
 
 extract_object_name <- function(parse_data, definition_id, assignment_ops) {

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -15,50 +15,56 @@ process_source_text_one <- function(text) {
   assignment_ops <- parse_data[
     parse_data$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN"),
   ]
-  # Assignments are the parent expressions of assignment operators
-  assignments <- parse_data[parse_data$id %in% assignment_ops$parent, ]
-  # Top-level expressions have a parent attribute of 0
-  object_definitions <- assignments[assignments$parent == 0, ]
+
+  object_definitions_idx <- which(
+    # Object definitions are the parent expressions of assignment operators
+    parse_data$id %in% assignment_ops$parent &
+      # Top-level expressions have a parent attribute of 0
+      parse_data$parent == 0,
+  )
+
+  object_definition_ids <- parse_data[object_definitions_idx, "id"]
 
   result <- list()
 
-  for (i in seq_len(nrow(object_definitions))) {
-    object_definition <- object_definitions[i, ]
+  for (i in seq_along(object_definition_ids)) {
+    id <- object_definition_ids[[i]]
 
-    names(result)[i] <- extract_object_name(
-      parse_data, object_definition, assignment_ops
-    )
+    start_line <- parse_data[parse_data$id == id, "line1"]
+    end_line <- parse_data[parse_data$id == id, "line2"]
 
-    # A leading comment's parent attribute is 0 - the next expression's id
-    leading_comments <- parse_data[parse_data$parent == -object_definition$id, ]
-
-    # Exclude leading comments if there are any empty lines between the comment
+    # A comment's parent attribute is 0 - the next expression's id
+    comments <- parse_data[parse_data$parent == -id, ]
+    # Include comments if there are no empty lines between the comment
     # and the object definition
-    leading_comments <- leading_comments[
-      object_definition$line1 - leading_comments$line1 <=
-        rev(seq_len(nrow(leading_comments))),
-    ]
-
-    staticexport_lines_idx <- seq(
-      min(leading_comments$line1, object_definition$line1),
-      max(leading_comments$line2, object_definition$line2)
+    leading_comments_idx <- which(
+      start_line - comments$line1 <= rev(seq_len(nrow(comments)))
     )
+    comment_lines <- comments[leading_comments_idx, "line1"]
+
+    staticexport_lines_idx <- seq(min(comment_lines, start_line), end_line)
     result[[i]] <- text[staticexport_lines_idx]
+
+    names(result)[[i]] <- extract_object_name(parse_data, id, assignment_ops)
   }
 
   result
 }
 
-extract_object_name <- function(parse_data, object_definition, assignment_ops) {
-  assignment <- assignment_ops[assignment_ops$parent == object_definition$id, ]
+extract_object_name <- function(parse_data, definition_id, assignment_ops) {
+  assignment_idx <- which(assignment_ops$parent == definition_id)
+  assignment_line <- assignment_ops[assignment_idx, "line1"]
+  assignment_col <- assignment_ops[assignment_idx, "col1"]
 
-  object_name_expr <- parse_data[
-    parse_data$parent == object_definition$id &
-      parse_data$line2 <= assignment$line1 &
-      parse_data$col2 < assignment$col1,
-  ]
+  object_name_idx <- which(
+    parse_data$parent == definition_id &
+      parse_data$line2 <= assignment_line &
+      parse_data$col2 < assignment_col
+  )
 
-  result <- utils::getParseText(parse_data, object_name_expr$id)
+  object_name_id <- parse_data[object_name_idx, "id"]
+
+  result <- utils::getParseText(parse_data, object_name_id)
 
   # Remove backticks, so that strings like "`%||%`" are converted to "%||%"
   if (grepl("^`\\S+`$", result)) {

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -29,19 +29,17 @@ process_source_file_one <- function(file) {
     # A leading comment's parent attribute is 0 - the next expression's id
     leading_comments <- parse_data[parse_data$parent == -object_definition$id, ]
 
-    # If there is no whitespace between a leading comment and object definition,
-    # expand the lines of the object definition to include the comment
-    j <- nrow(leading_comments)
-    while (j > 0) {
-      if (object_definition$line1 - leading_comments$line2[j] > 1) {
-        break
-      }
+    # Exclude leading comments if there are any empty lines between the comment
+    # and the object definition
+    leading_comments <- leading_comments[
+      object_definition$line1 - leading_comments$line1 <=
+        rev(seq_len(nrow(leading_comments))),
+    ]
 
-      object_definition$line1 <- leading_comments$line1[j]
-      j <- j - 1
-    }
-
-    staticexport_lines <- seq(object_definition$line1, object_definition$line2)
+    staticexport_lines <- seq(
+      min(leading_comments$line1, object_definition$line1),
+      max(leading_comments$line2, object_definition$line2)
+    )
     staticexport_text <- text[staticexport_lines]
     staticexports[[i]] <- staticexport_text
   }

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -1,13 +1,16 @@
-# Given a list of files, process the text and return a named list of objects.
-process_source_files <- function(files) {
-  results <- lapply(files, process_source_file_one)
+# Given a list of char vectors (each should be the output of `readLines()`),
+# process the text and return a named list of objects.
+process_source_texts <- function(source_texts) {
+  results <- lapply(source_texts, process_source_text_one)
   unlist(unname(results), recursive = FALSE)
 }
 
-# Given a file, process the text and return a named list of objects.
-process_source_file_one <- function(file) {
-  parse_data <- utils::getParseData(parse(file = file, keep.source = TRUE))
-  text <- readLines(file)
+# Given a char vector of lines (from readLines()), process the text and return a
+# named list of objects.
+process_source_text_one <- function(text) {
+  parse_data <- utils::getParseData(
+    parse(text = paste(text, collapse = "\n"), keep.source = TRUE)
+  )
 
   assignment_ops <- parse_data[
     parse_data$token %in% c("LEFT_ASSIGN", "EQ_ASSIGN", "RIGHT_ASSIGN"),

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -20,7 +20,7 @@ process_source_text_one <- function(text) {
   # Top-level expressions have a parent attribute of 0
   object_definitions <- assignments[assignments$parent == 0, ]
 
-  result <- vector("list", nrow(object_definitions))
+  result <- list()
 
   for (i in seq_len(nrow(object_definitions))) {
     object_definition <- object_definitions[i, ]

--- a/R/process_source.R
+++ b/R/process_source.R
@@ -63,7 +63,7 @@ extract_object_name <- function(parse_data, object_definition, assignment_ops) {
 
   # Remove backticks, so that strings like "`%||%`" are converted to "%||%"
   if (grepl("^`\\S+`$", result)) {
-    result <- sub("^`(\\S+)`$", "\\1", result, perl = TRUE)
+    result <- sub("^`(\\S+)`$", "\\1", result)
   }
 
   result

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -83,18 +83,11 @@ writeLines(
 # equals assign
 h = function(x, y) {
   x == y
-}
-
-# right assign
-list(
-  3,
-  2,
-  1
-) -> r", file.path(outdir, "file3.R"))
+}", file.path(outdir, "file3.R"))
 
   res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
 
-  expect_equal(names(res), c("h", "r"))
+  expect_equal(names(res), c("h"))
 
   expect_identical(
     res,
@@ -104,14 +97,6 @@ list(
         "h = function(x, y) {",
         "  x == y",
         "}"
-      ),
-      r = c(
-        "# right assign",
-        "list(",
-        "  3,",
-        "  2,",
-        "  1",
-        ") -> r"
       )
     )
   )

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -1,0 +1,64 @@
+test_that("staticexports source parsing", {
+  outdir <- tempfile("staticimports-test")
+  dir.create(outdir)
+  on.exit(unlink(outdir, recursive = TRUE))
+
+  writeLines(
+"# Comment attached to f
+f <- function() 123
+
+# Comment separated from g
+
+g <- local(
+  function() {
+    x <- 123
+    x
+  }
+)
+
+# Comment separated from x
+
+# Comment attached to x
+x <- list(
+  # Comment within the definition
+  1,
+  2,
+  3
+)
+", file.path(outdir, "file1.R"))
+
+  writeLines(
+    "`%infix%` <- function(lhs, rhs) lhs",
+    file.path(outdir, "file2.R")
+  )
+
+  res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
+
+  expect_identical(
+    res,
+    list(
+      f = c(
+        "# Comment attached to f",
+        "f <- function() 123"
+      ),
+      g = c(
+        "g <- local(",
+        "  function() {",
+        "    x <- 123",
+        "    x",
+        "  }",
+        ")"
+      ),
+      x = c(
+        "# Comment attached to x",
+        "x <- list(",
+        "  # Comment within the definition",
+        "  1,",
+        "  2,",
+        "  3",
+        ")"
+      ),
+      `%infix%` = "`%infix%` <- function(lhs, rhs) lhs"
+    )
+  )
+})

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -19,6 +19,7 @@ g <- local(
 # Comment separated from x
 
 # Comment attached to x
+# And another line
 x <- list(
   # Comment within the definition
 
@@ -54,6 +55,7 @@ x <- list(
       ),
       x = c(
         "# Comment attached to x",
+        "# And another line",
         "x <- list(",
         "  # Comment within the definition",
         "",

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -34,7 +34,7 @@ x <- list(
     file.path(outdir, "file2.R")
   )
 
-  res <- process_source_files(dir(outdir, full.names = TRUE))
+  res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
 
   expect_equal(names(res), c("f", "g", "x", "%infix%"))
 
@@ -92,7 +92,7 @@ list(
   1
 ) -> r", file.path(outdir, "file3.R"))
 
-  res <- process_source_files(dir(outdir, full.names = TRUE))
+  res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
 
   expect_equal(names(res), c("h", "r"))
 

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -33,24 +33,9 @@ x <- list(
     file.path(outdir, "file2.R")
   )
 
-  writeLines(
-"# other assigns
-
-# equals assign
-h = function(x, y) {
-  x == y
-}
-
-# right assign
-list(
-  3,
-  2,
-  1
-) -> r", file.path(outdir, "file3.R"))
-
   res <- process_source_files(dir(outdir, full.names = TRUE))
 
-  expect_equal(names(res), c("f", "g", "x", "%infix%", "h", "r"))
+  expect_equal(names(res), c("f", "g", "x", "%infix%"))
 
   expect_identical(
     res,
@@ -77,7 +62,41 @@ list(
         "  3",
         ")"
       ),
-      `%infix%` = "`%infix%` <- function(lhs, rhs) lhs",
+      `%infix%` = "`%infix%` <- function(lhs, rhs) lhs"
+    )
+  )
+})
+
+test_that("staticexports source parsing with uncommon assignment operators", {
+  # In R < 3.6, parse data does not properly keep track of assignments using `=`
+  skip_if(getRversion() < 3.6)
+
+  outdir <- tempfile("staticimports-test")
+  dir.create(outdir)
+  on.exit(unlink(outdir, recursive = TRUE))
+
+writeLines(
+"# other assigns
+
+# equals assign
+h = function(x, y) {
+  x == y
+}
+
+# right assign
+list(
+  3,
+  2,
+  1
+) -> r", file.path(outdir, "file3.R"))
+
+  res <- process_source_files(dir(outdir, full.names = TRUE))
+
+  expect_equal(names(res), c("h", "r"))
+
+  expect_identical(
+    res,
+    list(
       h = c(
         "# equals assign",
         "h = function(x, y) {",

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -34,6 +34,8 @@ x <- list(
 
   res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
 
+  expect_equal(names(res), c("f", "g", "x", "%infix%"))
+
   expect_identical(
     res,
     list(

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -48,7 +48,7 @@ list(
   1
 ) -> r", file.path(outdir, "file3.R"))
 
-  res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
+  res <- process_source_files(dir(outdir, full.names = TRUE))
 
   expect_equal(names(res), c("f", "g", "x", "%infix%", "h", "r"))
 

--- a/tests/testthat/test-process_source.R
+++ b/tests/testthat/test-process_source.R
@@ -21,6 +21,7 @@ g <- local(
 # Comment attached to x
 x <- list(
   # Comment within the definition
+
   1,
   2,
   3
@@ -32,9 +33,24 @@ x <- list(
     file.path(outdir, "file2.R")
   )
 
+  writeLines(
+"# other assigns
+
+# equals assign
+h = function(x, y) {
+  x == y
+}
+
+# right assign
+list(
+  3,
+  2,
+  1
+) -> r", file.path(outdir, "file3.R"))
+
   res <- process_source_texts(lapply(dir(outdir, full.names = TRUE), readLines))
 
-  expect_equal(names(res), c("f", "g", "x", "%infix%"))
+  expect_equal(names(res), c("f", "g", "x", "%infix%", "h", "r"))
 
   expect_identical(
     res,
@@ -55,12 +71,27 @@ x <- list(
         "# Comment attached to x",
         "x <- list(",
         "  # Comment within the definition",
+        "",
         "  1,",
         "  2,",
         "  3",
         ")"
       ),
-      `%infix%` = "`%infix%` <- function(lhs, rhs) lhs"
+      `%infix%` = "`%infix%` <- function(lhs, rhs) lhs",
+      h = c(
+        "# equals assign",
+        "h = function(x, y) {",
+        "  x == y",
+        "}"
+      ),
+      r = c(
+        "# right assign",
+        "list(",
+        "  3,",
+        "  2,",
+        "  1",
+        ") -> r"
+      )
     )
   )
 })


### PR DESCRIPTION
This PR refactors `process_source_text_one()` to extract object definitions from source text using R's parse data.

For example, with this input:

``` r
writeLines("
# Comment attached to f
f <- function() 123

# Comment separated from g

g <- local(
  function() {
    x <- 123
    x
  }
)

# Comment separated from x

# Comment attached to x
x <- list(
  # Comment within the definition
  1,
  2,
  3
)

`%infix%` <- function(lhs, rhs) lhs
",
file <- tempfile()
)
```

we get this result:

``` r
process_source_text_one(readLines(file))
#> $f
#> [1] "# Comment attached to f"
#> [2] "f <- function() 123"    
#> 
#> $g
#> [1] "g <- local("   
#> [2] "  function() {"
#> [3] "    x <- 123"  
#> [4] "    x"         
#> [5] "  }"           
#> [6] ")"             
#> 
#> $x
#> [1] "# Comment attached to x"          
#> [2] "x <- list("                       
#> [3] "  # Comment within the definition"
#> [4] "  1,"                             
#> [5] "  2,"                             
#> [6] "  3"                              
#> [7] ")"                                
#> 
#> $`%infix%`
#> [1] "`%infix%` <- function(lhs, rhs) lhs"
```

<sup>Created on 2022-10-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #20.