### PR TITLE
Remove caveat about packages that are installed later

### DIFF
--- a/inst/staticexports/package.R
+++ b/inst/staticexports/package.R
@@ -71,8 +71,9 @@ system_file <- function(..., package = "base") {
   normalizePath(files, winslash = "/")
 }
 
-# A wrapper for `system.file()`, which caches the package file path.
-# Note, only non-empty paths are cached.
+# A wrapper for `system.file()`, which caches the package path because
+# `system.file()` can be slow. If a package is not installed, the result won't
+# be cached.
 system_file_cached <- local({
   pkg_dir_cache <- character()
 

--- a/inst/staticexports/package.R
+++ b/inst/staticexports/package.R
@@ -71,11 +71,8 @@ system_file <- function(..., package = "base") {
   normalizePath(files, winslash = "/")
 }
 
-# A wrapper for `system.file()`, which caches the results, because
-# `system.file()` can be slow. Note that because of caching, if
-# `system_file_cached()` is called on a package that isn't installed, then the
-# package is installed, and then `system_file_cached()` is called again, it will
-# still return "".
+# A wrapper for `system.file()`, which caches the package file path.
+# Note, only non-empty paths are cached.
 system_file_cached <- local({
   pkg_dir_cache <- character()
 
@@ -87,7 +84,9 @@ system_file_cached <- local({
     not_cached <- is.na(match(package, names(pkg_dir_cache)))
     if (not_cached) {
       pkg_dir <- system.file(package = package)
-      pkg_dir_cache[[package]] <<- pkg_dir
+      if (nzchar(pkg_dir)) {
+        pkg_dir_cache[[package]] <<- pkg_dir
+      }
     } else {
       pkg_dir <- pkg_dir_cache[[package]]
     }


### PR DESCRIPTION
If the package is not found right now, it should be ok to slow down the method. Once found, it'll be fast.