### PR TITLE
feat: `is_r_version()`

### DIFF
--- a/inst/staticexports/os.R
+++ b/inst/staticexports/os.R
@@ -19,3 +19,31 @@ os_name <- function() {
     "unknown"
   }
 }
+
+is_r_version <- function(min, max = min) {
+  v <- .get_r_version()
+
+  if (missing(min)) min <- NULL
+  if (is.null(min)) min <- "0.0.0"
+  stopifnot(is.character(min))
+
+  if (is.character(min) && missing(max)) {
+    min_len <- length(strsplit(min, "\\.")[[1]])
+    if (min_len == 1) {
+      max <- paste0(min, ".9999.9999")
+      min <- paste0(min, ".0.0")
+    } else if (min_len == 2) {
+      max <- paste0(min, ".9999")
+      min <- paste0(min, ".0")
+    }
+  }
+
+  if (is.null(max)) max <- max(min, as.character(v))
+  stopifnot(is.character(max))
+
+  v >= min && v <= max
+}
+
+.get_r_version <- function() {
+  getRversion()
+}

--- a/tests/testthat/test-os.R
+++ b/tests/testthat/test-os.R
@@ -1,0 +1,28 @@
+test_that("is_r_version() works", {
+  load_exports()
+
+  assign(".get_r_version", function() package_version("4.2.2"), exports)
+  expect_true(is_r_version("4.2.2"))
+  expect_true(is_r_version("4.2"))
+  expect_true(is_r_version("4"))
+  expect_true(is_r_version("3.6.3", "4.2.2"))
+  expect_true(is_r_version(max = "4.3"))
+
+  expect_false(is_r_version("3", "4"))
+  expect_false(is_r_version(max = "3.6"))
+  expect_false(is_r_version("4.2.1"))
+
+  assign(".get_r_version", function() package_version("3.6.3"), exports)
+  expect_true(is_r_version("3.6.3"))
+  expect_true(is_r_version("3.6"))
+  expect_true(is_r_version("3"))
+
+  expect_false(is_r_version("4"))
+  expect_false(is_r_version("3.6.4"))
+  expect_false(is_r_version(max = "3.5"))
+  expect_false(is_r_version("4.2.3"))
+
+  expect_error(is_r_version(min = 4))
+  expect_error(is_r_version(max = 4))
+  expect_error(is_r_version(min = "abcd"))
+})


### PR DESCRIPTION
Adds a helper function to test the current version of R, with arguments for `min` or `max` version.

``` r
getRversion()
#> [1] '4.3.0'
```

When only `min` is provided, there are a few conveniences to select patch, minor or major versions.

```r
# Is R this specific version?
is_r_version("4.3.0")
#> [1] TRUE

# Is R this minor version?
is_r_version("4.3")
#> [1] TRUE

# Is R this major version?
is_r_version("4")
#> [1] TRUE

is_r_version("3")
#> [1] FALSE
```

Or use `min` and `max` together to check for a range of versions.

```r
# Is R this version or higher?
is_r_version(min = "3.6", max = NULL)
#> [1] TRUE

# Is R at or below this version?
is_r_version(max = "3.6.3")
#> [1] FALSE

# Is R between these specific versions?
is_r_version("4.2.1", "4.2.3")
#> [1] FALSE
```